### PR TITLE
Fix deprecated OptionsFlowWithConfigEntry for HA 2026.2

### DIFF
--- a/custom_components/htd/config_flow.py
+++ b/custom_components/htd/config_flow.py
@@ -4,7 +4,7 @@ from typing import Any
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow, OptionsFlowWithConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_UNIQUE_ID
 from homeassistant.core import callback, HomeAssistant
 from htd_client import async_get_model_info
@@ -110,7 +110,7 @@ class HtdConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
-        return HtdOptionsFlowHandler(config_entry)
+        return HtdOptionsFlowHandler()
 
     async def async_step_options(self, user_input=None):
         if user_input is not None:
@@ -137,7 +137,7 @@ class HtdConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
 
-class HtdOptionsFlowHandler(OptionsFlowWithConfigEntry):
+class HtdOptionsFlowHandler(OptionsFlow):
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
         if user_input is not None:
             options = {

--- a/custom_components/htd/manifest.json
+++ b/custom_components/htd/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "htd_client==0.0.24"
   ],
-  "version": "2.0.0-rc.3"
+  "version": "2.0.0-rc.4"
 }


### PR DESCRIPTION
## Summary
- Replace `OptionsFlowWithConfigEntry` with `OptionsFlow` — the former is deprecated and kept only for backward compatibility
- Stop explicitly passing `config_entry` to `HtdOptionsFlowHandler()` — HA injects it automatically since 2025.12 (manually setting it logs warnings and will break)
- Bump version to `2.0.0-rc.4` so HACS presents the update to users

These changes complement commit c7bd69e which fixed the `DhcpServiceInfo` import. Together they resolve the `AttributeError` on HA 2026.2 where `homeassistant.components.dhcp.DhcpServiceInfo` was removed, and prevent the deprecated options flow pattern from breaking in future HA releases.

## References
- [Relocated ServiceInfo models (DhcpServiceInfo removed from old path in 2026.2)](https://developers.home-assistant.io/blog/2025/01/15/service-info/)
- [New options flow properties (OptionsFlowWithConfigEntry deprecated)](https://developers.home-assistant.io/blog/2024/11/12/options-flow/)

## Test plan
- [ ] Install updated integration on HA 2026.2
- [ ] Verify integration loads without import errors
- [ ] Verify DHCP auto-discovery still works
- [ ] Verify options flow (reconfiguring host/port) still works
- [ ] Confirm HACS detects the version bump and offers the update